### PR TITLE
Fix rebind.cpp

### DIFF
--- a/examples/cpp/rebind/rebind.cpp
+++ b/examples/cpp/rebind/rebind.cpp
@@ -516,7 +516,7 @@ int main()
 	std::wstring app_name_w;
 
 	std::cout << std::endl << "Application name to rebind: ";
-	std::wcin >> app_name_w;
+	std::getline(std::wcin, app_name_w);
 
 	rebind.set_application_name(app_name_w);
 


### PR DESCRIPTION
When used this way:
start cmd /k "echo Prog ram Name | rebind"

There is a problem that only the part of the name before the space is included in the input.